### PR TITLE
fix ErrorHandling

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -14,7 +14,7 @@ sendInitError () {
   ERROR_MESSAGE=$1
   ERROR_TYPE=$2
   ERROR="{\"errorMessage\": \"$ERROR_MESSAGE\", \"errorType\": \"$ERROR_TYPE\"}"
-  curl -sS -X POST -d "$ERROR" "http://${AWS_LAMBDA_RUNTIME_API}/${RUNTIME_PATH}/init/error" > /dev/null
+  curl -sS -X POST -d "$ERROR" --header "Lambda-Runtime-Function-Error-Type: Unhandled" "http://${AWS_LAMBDA_RUNTIME_API}/${RUNTIME_PATH}/init/error" > /dev/null
 }
 
 # Send runtime error to Lambda API
@@ -24,7 +24,8 @@ sendRuntimeError () {
   ERROR_TYPE=$3
   STACK_TRACE=$4
   ERROR="{\"errorMessage\": \"$ERROR_MESSAGE\", \"errorType\": \"$ERROR_TYPE\", \"stackTrace\": \"$STACK_TRACE\"}"
-  curl -sS -X POST -d "$ERROR" "http://${AWS_LAMBDA_RUNTIME_API}/${RUNTIME_PATH}/invocation/${REQUEST_ID}/error" > /dev/null
+  curl -sS -X POST -d "$ERROR" --header "Lambda-Runtime-Function-Error-Type: Unhandled" "http://${AWS_LAMBDA_RUNTIME_API}/${RUNTIME_PATH}/invocation/${REQUEST_ID}/error" > /dev/null
+
 }
 
 # Send successful response to Lambda API


### PR DESCRIPTION
## background

There is a case where the execution of Lambda function fails and the Task of Step Functions becomes Success.
When I contacted AWS Support, it seems that it is because the error handling method described in the document is different.

## Content

ref https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-invokeerror
Corrected error handling to match the above documentation.
Specifically added missing headers.