### PR TITLE
use kv2json for Error Body build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .vscode
 export
 
+# Download bin/package
+bin/kv2json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /usr/bin/env bash -xe
 
 PWD := $(shell pwd)
 
-build:
+build: bin/kv2json
 	@rm -rf export
 	@mkdir export
 	@zip -yr export/layer.zip bootstrap bin lib libexec share
@@ -25,6 +25,10 @@ update-awscli:
 		lambci/lambda:build-python3.6 \
 		bash -c /root/bash-lambda-layer/update-awscli.sh
 
+bin/kv2json:
+	cd bin/ \
+		&& curl -sOL https://raw.githubusercontent.com/Songmu/App-KV2JSON/master/kv2json \
+		&& chmod +x kv2json
 
 .PHONY: \
 	build

--- a/bootstrap
+++ b/bootstrap
@@ -13,7 +13,7 @@ export AWS_CONFIG_FILE="/tmp/.aws/config"
 sendInitError () {
   ERROR_MESSAGE=$1
   ERROR_TYPE=$2
-  ERROR="{\"errorMessage\": \"$ERROR_MESSAGE\", \"errorType\": \"$ERROR_TYPE\"}"
+  ERROR=$(kv2json errorMessage="$ERROR_MESSAGE" errorType="$ERROR_TYPE" )
   curl -sS -X POST -d "$ERROR" --header "Lambda-Runtime-Function-Error-Type: Unhandled" "http://${AWS_LAMBDA_RUNTIME_API}/${RUNTIME_PATH}/init/error" > /dev/null
 }
 
@@ -23,7 +23,7 @@ sendRuntimeError () {
   ERROR_MESSAGE=$2
   ERROR_TYPE=$3
   STACK_TRACE=$4
-  ERROR="{\"errorMessage\": \"$ERROR_MESSAGE\", \"errorType\": \"$ERROR_TYPE\", \"stackTrace\": \"$STACK_TRACE\"}"
+  ERROR=$(kv2json errorMessage="$ERROR_MESSAGE" errorType="$ERROR_TYPE" stackTrace="$STACK_TRACE")
   curl -sS -X POST -d "$ERROR" --header "Lambda-Runtime-Function-Error-Type: Unhandled" "http://${AWS_LAMBDA_RUNTIME_API}/${RUNTIME_PATH}/invocation/${REQUEST_ID}/error" > /dev/null
 
 }


### PR DESCRIPTION
## background

If there is something like the following that breaks the JSON structure in the stack trace, the JSON of Body will be broken.
```
error \"hoge\" is not found
```
In this case,
```
{\"errorMessage\": \"ERROR_MESSAGE\", \"errorType\": \"ERROR_TYPE\", \"stackTrace\": \"error \"hoge\" is not found\"}"
```

The problem is that JSON is not escaped when creating the Body.

## content

use kv2json  https://github.com/Songmu/App-KV2JSON

kv2json is very useful when assembling json from environment variables.
By generating an Error Body using kv2json, it is possible to generate it no matter what character string is in it.
 