### PR TITLE
 Release for our organization

### DIFF
--- a/publish-only.sh
+++ b/publish-only.sh
@@ -2,7 +2,7 @@
 GIT_VER=$(git describe --tags)
 DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
 DESCRIPTION="Bash in AWS Lambda version $GIT_VER [https://github.com/kayac/bash-lambda-layer]
-published in $DATE
+published at $DATE
 "
 
 # AWS Regions

--- a/publish-only.sh
+++ b/publish-only.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -e
+GIT_VER=$(git describe --tags)
+DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
+DESCRIPTION="Bash in AWS Lambda version $GIT_VER [https://github.com/kayac/bash-lambda-layer]
+published in $DATE
+"
 
 # AWS Regions
 region=${AWS_REGION:?no-region}
@@ -6,7 +11,7 @@ LAYER_NAME="bash"
 
 echo "Publishing layer to $region..."
 
-LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "Bash in AWS Lambda [https://github.com/gkrizek/bash-lambda-layer]" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
+LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "$DESCRIPTION" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
 
 echo $LAYER_ARN
 echo ""

--- a/publish-only.sh
+++ b/publish-only.sh
@@ -12,6 +12,16 @@ LAYER_NAME="bash"
 echo "Publishing layer to $region..."
 
 LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "$DESCRIPTION" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
+if [ -n "$PERMISSION" ]; then
+    POLICY=$(aws lambda add-layer-version-permission \
+        --region $region \
+        --layer-name $LAYER_NAME \
+        --version-number $(echo -n $LAYER_ARN | tail -c 1) \
+        --statement-id $LAYER_NAME-public \
+        --action lambda:GetLayerVersion \
+        $PERMISSION)
+    echo $POLICY
+fi
 
 echo $LAYER_ARN
 echo ""

--- a/publish-staging.sh
+++ b/publish-staging.sh
@@ -2,7 +2,7 @@
 GIT_VER=$(git describe --tags)
 DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
 DESCRIPTION="Bash in AWS Lambda version $GIT_VER [https://github.com/kayac/bash-lambda-layer]
-published in $DATE
+published at $DATE
 "
 
 # AWS Regions

--- a/publish-staging.sh
+++ b/publish-staging.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -e
+GIT_VER=$(git describe --tags)
+DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
+DESCRIPTION="Bash in AWS Lambda version $GIT_VER [https://github.com/kayac/bash-lambda-layer]
+published in $DATE
+"
 
 # AWS Regions
 REGIONS=(
@@ -9,8 +14,8 @@ LAYER_NAME="bash-testing"
 for region in ${REGIONS[@]}; do
     echo "Publishing layer to $region..."
 
-    LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "Bash in AWS Lambda [https://github.com/gkrizek/bash-lambda-layer]" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
-    
+    LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "$DESCRIPTION" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
+
     echo $LAYER_ARN
     echo "$region complete for Staging"
     echo ""

--- a/publish-staging.sh
+++ b/publish-staging.sh
@@ -2,7 +2,7 @@
 
 # AWS Regions
 REGIONS=(
-    "us-west-2"
+    "${AWS_REGION:?no-region}"
 )
 LAYER_NAME="bash-testing"
 

--- a/publish-staging.sh
+++ b/publish-staging.sh
@@ -15,6 +15,16 @@ for region in ${REGIONS[@]}; do
     echo "Publishing layer to $region..."
 
     LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "$DESCRIPTION" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
+    if [ -n "$PERMISSION" ]; then
+        POLICY=$(aws lambda add-layer-version-permission \
+            --region $region \
+            --layer-name $LAYER_NAME \
+            --version-number $(echo -n $LAYER_ARN | tail -c 1) \
+            --statement-id $LAYER_NAME-public \
+            --action lambda:GetLayerVersion \
+            $PERMISSION)
+        echo $POLICY
+    fi
 
     echo $LAYER_ARN
     echo "$region complete for Staging"

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -e
+GIT_VER=$(git describe --tags)
+DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
+DESCRIPTION="Bash in AWS Lambda version $GIT_VER [https://github.com/kayac/bash-lambda-layer]
+published in $DATE
+"
 
 # AWS Regions
 REGIONS=(
@@ -24,9 +29,9 @@ LAYER_NAME="bash"
 for region in ${REGIONS[@]}; do
     echo "Publishing layer to $region..."
 
-    LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "Bash in AWS Lambda [https://github.com/gkrizek/bash-lambda-layer]" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
+    LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name $LAYER_NAME --description "$DESCRIPTION" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
     POLICY=$(aws lambda add-layer-version-permission --region $region --layer-name $LAYER_NAME --version-number $(echo -n $LAYER_ARN | tail -c 1) --statement-id $LAYER_NAME-public --action lambda:GetLayerVersion --principal \*)
-    
+
     echo $LAYER_ARN
     echo "$region complete"
     echo ""

--- a/publish.sh
+++ b/publish.sh
@@ -2,7 +2,7 @@
 GIT_VER=$(git describe --tags)
 DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
 DESCRIPTION="Bash in AWS Lambda version $GIT_VER [https://github.com/kayac/bash-lambda-layer]
-published in $DATE
+published at $DATE
 "
 
 # AWS Regions


### PR DESCRIPTION
## background

This repository was forked because I wanted to upgrade the AWS CLI version more often than the original bash-lambda-layer
Modify the deployment script for usability within our organization.

## content

- Modify layer description
  - include version info
  - change repository

- For testing layer utilization
  - selectable region
  - selectable permission

## how to deploy
0. build
```
make build
```

1. for testing
```
PERMISSION="--principal $DEV_AWS_ACCOUNT_ID" AWS_REGION=ap-northeast-1 make publish-staging 
```

2-1. publish local
```
PERMISSION="--organization-id $AWS_ORG_ID --principal '*'" AWS_REGION=ap-northeast-1 make publish-only
```

2-2. publish-global
```
make publish
```