### PR TITLE
Fix Github actions build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: for install awscli /opt/bin symbolic link
+        run: ln -s $GITHUB_WORKSPACE/bin /opt/bin
       - name: Build Layer
         run: |
           make packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,15 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build Layer
+      - name: Build Layer on docker
         run: |
           make build_on_docker
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Create Release Package
-        run: |
-          make packages
       - name: Create a Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
           asset_name: bash-lambda-layer.zip
           asset_content_type: application/zip
       - name: Publish
+        if: ! contains(github.ref, 'alpha')
         run: |
           make publish
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: for install awscli /opt/bin symbolic link
-        run: ln -s $GITHUB_WORKSPACE/bin /opt/bin
       - name: Build Layer
         run: |
-          make packages
+          make build_on_docker
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Create Release Package
+        run: |
+          make packages
       - name: Create a Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           asset_name: bash-lambda-layer.zip
           asset_content_type: application/zip
       - name: Publish
-        if: ! contains(github.ref, 'alpha')
+        if: contains(github.ref, 'alpha') != true
         run: |
           make publish
         env:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PWD := $(shell pwd)
 
 build_on_docker: archives/awscli-exe-linux-x86_64-$(AWSCLI_VERSION).zip
 	docker build -t bash-lambda-layer-builder docker/builder
-	docker run -it -v $(PWD):/root/bash-lambda-layer -v $(PWD)/bin:/opt/bin \
+	docker run -v $(PWD):/root/bash-lambda-layer -v $(PWD)/bin:/opt/bin \
 		--workdir="/root/bash-lambda-layer" \
 		bash-lambda-layer-builder \
 		make build

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ build: bin/kv2json awscli
 	@rm -rf export
 	@mkdir export
 	@zip -yr export/layer.zip bootstrap bin lib libexec share
-
-packages: export/layer.zip
 	@zip -yr export/bash-lambda-layer.zip export/layer.zip publish.sh publish-only.sh README.publish.md
 
 publish:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: bin/kv2json awscli
 	@mkdir export
 	@zip -yr export/layer.zip bootstrap bin lib libexec share
 
-packages: build
+packages: export/layer.zip
 	@zip -yr export/bash-lambda-layer.zip export/layer.zip publish.sh publish-only.sh README.publish.md
 
 publish:


### PR DESCRIPTION

## What is this?

When building on docker container, $(repo root)/bin was mounted on /opt/bin.
This is the relationship of the symbolic link when installing awscli.
When building on github actions, the countermeasure is not taken, so the layer vsersion2 released in production did not have aws cli installed.